### PR TITLE
Rename Editor role to new naming

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -3,6 +3,6 @@ resources:
     RobertLemke_Plugin_Blog_PostController: 'method(RobertLemke\Plugin\Blog\Controller\PostController->createAction())'
 
 acls:
-  Editor:
+  TYPO3.Neos:Editor:
     methods:
       RobertLemke_Plugin_Blog_PostController: GRANT


### PR DESCRIPTION
Fix the editor's role is Policy.yaml to fit the recently adjusted role naming.
