### PR TITLE
Drop deprecated FILTER_SANITIZE_STRIPPED type

### DIFF
--- a/Classes/Controller/CommentController.php
+++ b/Classes/Controller/CommentController.php
@@ -66,9 +66,9 @@ class CommentController extends ActionController
             $this->throwStatus(400, 'Your comment was NOT created - it was too short.');
         }
 
-        $newComment->setProperty('text', filter_var($newComment->getProperty('text'), FILTER_SANITIZE_STRIPPED));
-        $newComment->setProperty('author', filter_var($newComment->getProperty('author'), FILTER_SANITIZE_STRIPPED));
-        $newComment->setProperty('emailAddress', filter_var($newComment->getProperty('emailAddress'), FILTER_SANITIZE_STRIPPED));
+        $newComment->setProperty('text', htmlspecialchars($newComment->getProperty('text')));
+        $newComment->setProperty('author', htmlspecialchars($newComment->getProperty('author')));
+        $newComment->setProperty('emailAddress', htmlspecialchars($newComment->getProperty('emailAddress')));
 
         $commentNode = $postNode->getNode('comments')->createNodeFromTemplate($newComment, uniqid('comment-', true));
         $commentNode->setProperty('spam', false);


### PR DESCRIPTION
The `FILTER_SANITIZE_STRIPPED` type for `filter_var()` is deprecated
as of PHP 8.1, `htmlspecialchars()` should be used instead.